### PR TITLE
Fix video removal

### DIFF
--- a/yt-playlists-delete-enhancer.js
+++ b/yt-playlists-delete-enhancer.js
@@ -158,7 +158,7 @@ class GMScript {
                     && overlay.thumbnailOverlayResumePlaybackRenderer.percentDurationWatched >= watchTimeValue
                 )
             )
-            .map(({playlistVideoRenderer: vid}) => (vid.setVideoId || vid.videoId));
+            .map(({playlistVideoRenderer: vid}) => (vid.videoId));
         return idsToDelete;
     }
 


### PR DESCRIPTION
This pull request adds support for the new API endpoint, getting the video IDs was changed slightly as well. The [Reverse engineering Javascript behind Google+ button](https://stackoverflow.com/questions/16907352/reverse-engineering-javascript-behind-google-button) question along with the [YouTube Playlist Duration Sort](https://greasyfork.org/en/scripts/412659-youtube-playlist-duration-sort/code) script were used as a guide.

Fixes https://github.com/avallete/yt-playlists-delete-enhancer/issues/4.