### PR TITLE
Hide videos instead of removing from the DOM

### DIFF
--- a/yt-playlists-delete-enhancer.js
+++ b/yt-playlists-delete-enhancer.js
@@ -166,7 +166,7 @@ class GMScript {
               const videoId = this.playlistVideos.filter(v => v.playlistVideoRenderer.setVideoId == id)[0].playlistVideoRenderer.videoId;
               const videoRenderer = document.querySelector(`ytd-playlist-video-renderer a[href^="/watch?v=${videoId}"]#thumbnail`);
               if (videoRenderer) {
-                videoRenderer.parentElement.parentElement.parentElement.parentElement.remove();
+                videoRenderer.parentElement.parentElement.parentElement.parentElement.style.display = 'none';
               } else {
                 window.location.reload();
               }


### PR DESCRIPTION
This pull request hides the `ytd-playlist-video-renderer` elements instead of removing them. Removing them would result in the "Remove from..." functionality removing the wrong element from the DOM as it appears to be index-based.