### PR TITLE
fix UI bug

### DIFF
--- a/cypress/integration/simple.spec.ts
+++ b/cypress/integration/simple.spec.ts
@@ -5,6 +5,11 @@ describe('test extension', () => {
   // TODO: Add more e2e tests when youtube webapp is not a nightmare to work with cypress anymore
   // as today, it's near impossible to do anything close to end user interactions (like login)
   it('extension load and set run attr to <html> tag', () => {
+    // mock youtube website to avoid redirect to 'https://consent.youtube.com'
+    cy.intercept('https://www.youtube.com', {
+      statusCode: 200,
+      body: '<html><body><div>mocked youtube</div></body></html>',
+    })
     cy.visit('https://www.youtube.com')
     cy.get('html').should('have.attr', `data-${U.id}-has-run`)
   })

--- a/src/operations/actions/append-app-to-dom.tsx
+++ b/src/operations/actions/append-app-to-dom.tsx
@@ -7,7 +7,9 @@ export default function appendAppToDom(config: YTConfigData, playlistName: strin
   const elementToAppendTo = getElementsByXpath(xpathRoot)[0] as Element
   if (elementToAppendTo) {
     render(
-      <RemoveVideoEnhancerApp config={config} playlistName={playlistName} />,
+      // Use Date.now() to force re-mount component to trigger playlist fetch after yt-navigate-finish events
+      // See: #62
+      <RemoveVideoEnhancerApp key={Date.now()} config={config} playlistName={playlistName} />,
       elementToAppendTo,
       elementToAppendTo.lastElementChild as Element
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use `Date.now()` as component key to force re-mount the app when after navigations events to re-fetch new playlist data.

Fix an issue with e2e testing by mocking the youtube website and avoid redirection to `https://consent.youtube.com`

## Related Issue

#62 

## Closing issues

closes 62
