### PR TITLE
Fix video decrement when playlist contains one video

### DIFF
--- a/src/operations/ui/decrement-number-of-videos-in-playlist.ts
+++ b/src/operations/ui/decrement-number-of-videos-in-playlist.ts
@@ -8,6 +8,17 @@ export default function decrementNumberOfVideosInPlaylist(value: number) {
     const newValue = Number(spanElement.textContent) - value
     spanElement.textContent = `${newValue}`
   } else {
-    throw new Error('span with the number of videos in playlist not found in DOM')
+    const spanElementOneVideo: HTMLSpanElement = getElementsByXpath(
+      XPATH.YT_NUMBER_OF_VIDEOS_IN_PLAYLIST_ONE_VIDEO
+    )[0] as HTMLSpanElement
+    if (spanElementOneVideo) {
+      // A reload is performed to properly restore the state of an empty playlist:
+      // - The "There are no videos in this playlist yet" text
+      // - The "No videos" text
+      // Both strings are not part of the `yt.msgs_` object to use for localization
+      window.location.reload()
+    } else {
+      throw new Error('span with the number of videos in playlist not found in DOM')
+    }
   }
 }

--- a/src/operations/ui/decrement-number-of-videos-in-playlist.ts
+++ b/src/operations/ui/decrement-number-of-videos-in-playlist.ts
@@ -3,7 +3,7 @@ import getElementsByXpath from '~src/lib/get-elements-by-xpath'
 
 // Decrement the numbers of videos in the playlist in the UI
 export default function decrementNumberOfVideosInPlaylist(value: number) {
-  const spanElement: HTMLSpanElement = getElementsByXpath(XPATH.YT_NUMBERS_OF_VIDEOS_IN_PLAYLIST)[0] as HTMLSpanElement
+  const spanElement: HTMLSpanElement = getElementsByXpath(XPATH.YT_NUMBER_OF_VIDEOS_IN_PLAYLIST)[0] as HTMLSpanElement
   if (spanElement) {
     const newValue = Number(spanElement.textContent) - value
     spanElement.textContent = `${newValue}`

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -2,7 +2,7 @@ export const XPATH = {
   APP_RENDER_ROOT: '//ytd-playlist-sidebar-renderer/div[@id="items"]/*[last()]',
   YT_PLAYLIST_SIDEBAR_ITEMS: '//ytd-playlist-sidebar-renderer/div[@id="items"]',
   YT_PLAYLIST_VIDEO_RENDERERS: '//ytd-playlist-video-renderer',
-  YT_NUMBERS_OF_VIDEOS_IN_PLAYLIST: '//ytd-playlist-sidebar-primary-info-renderer/div/yt-formatted-string/span[1]',
+  YT_NUMBER_OF_VIDEOS_IN_PLAYLIST: '//ytd-playlist-sidebar-primary-info-renderer/div/yt-formatted-string/span[1]',
   YT_NUMBER_OF_VIDEOS_IN_PLAYLIST_ONE_VIDEO: '//ytd-playlist-sidebar-primary-info-renderer/div/yt-formatted-string',
 }
 

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -3,6 +3,7 @@ export const XPATH = {
   YT_PLAYLIST_SIDEBAR_ITEMS: '//ytd-playlist-sidebar-renderer/div[@id="items"]',
   YT_PLAYLIST_VIDEO_RENDERERS: '//ytd-playlist-video-renderer',
   YT_NUMBERS_OF_VIDEOS_IN_PLAYLIST: '//ytd-playlist-sidebar-primary-info-renderer/div/yt-formatted-string/span[1]',
+  YT_NUMBER_OF_VIDEOS_IN_PLAYLIST_ONE_VIDEO: '//ytd-playlist-sidebar-primary-info-renderer/div/yt-formatted-string',
 }
 
 export default {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
An error occurs when a single video is removed from a playlist containing only one video. This is due to the markup being different when there are one or zero videos. A page reload is needed as it doesn't seem possible to localize the text changes into other languages.

## How Has This Been Tested?
In the browser with English and German.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.