### PR TITLE
Fix video removal

### DIFF
--- a/src/components/remove-video-enhancer-app.tsx
+++ b/src/components/remove-video-enhancer-app.tsx
@@ -44,7 +44,7 @@ export default class RemoveVideoEnhancerApp extends Component<Properties, State>
         try {
           await removeVideosFromPlaylist(this.props.config, playlist?.playlistId as string, toDeleteVideos)
           playlist.continuations[0].videos = toKeepVideos
-          removeVideosFromPlaylistUI(playlist, toDeleteVideos)
+          removeVideosFromPlaylistUI(toDeleteVideos)
           this.setState({ ...this.state, playlist })
         } catch (error) {
           this.setState({ ...this.state, errorMessages: [error.message] })

--- a/src/components/remove-video-enhancer-app.tsx
+++ b/src/components/remove-video-enhancer-app.tsx
@@ -44,7 +44,7 @@ export default class RemoveVideoEnhancerApp extends Component<Properties, State>
         try {
           await removeVideosFromPlaylist(this.props.config, playlist?.playlistId as string, toDeleteVideos)
           playlist.continuations[0].videos = toKeepVideos
-          removeVideosFromPlaylistUI(toDeleteVideos)
+          removeVideosFromPlaylistUI(playlist, toDeleteVideos)
           this.setState({ ...this.state, playlist })
         } catch (error) {
           this.setState({ ...this.state, errorMessages: [error.message] })

--- a/src/operations/actions/remove-videos-from-playlist-ui.ts
+++ b/src/operations/actions/remove-videos-from-playlist-ui.ts
@@ -1,10 +1,10 @@
-import hideVideosFromPlaylistUi from '~src/operations/ui/hide-videos-from-playlist-ui'
+import removeVideosFromPlaylist from '~src/operations/ui/remove-videos-from-playlist'
 import decrementNumberOfVideosInPlaylist from '~src/operations/ui/decrement-number-of-videos-in-playlist'
-import { PlaylistVideo } from '~src/youtube'
+import { Playlist, PlaylistVideo } from '~src/youtube'
 
-export default function removeVideosFromPlaylistUI(toDeleteVideos: PlaylistVideo[]) {
+export default function removeVideosFromPlaylistUI(playlist: Playlist, toDeleteVideos: PlaylistVideo[]) {
   try {
-    hideVideosFromPlaylistUi(toDeleteVideos)
+    removeVideosFromPlaylist(playlist, toDeleteVideos)
     decrementNumberOfVideosInPlaylist(toDeleteVideos.length)
   } catch {
     // If an error occurs while trying to dynamically update the UI

--- a/src/operations/actions/remove-videos-from-playlist-ui.ts
+++ b/src/operations/actions/remove-videos-from-playlist-ui.ts
@@ -1,10 +1,10 @@
 import removeVideosFromPlaylist from '~src/operations/ui/remove-videos-from-playlist'
 import decrementNumberOfVideosInPlaylist from '~src/operations/ui/decrement-number-of-videos-in-playlist'
-import { Playlist, PlaylistVideo } from '~src/youtube'
+import { PlaylistVideo } from '~src/youtube'
 
-export default function removeVideosFromPlaylistUI(playlist: Playlist, toDeleteVideos: PlaylistVideo[]) {
+export default function removeVideosFromPlaylistUI(toDeleteVideos: PlaylistVideo[]) {
   try {
-    removeVideosFromPlaylist(playlist, toDeleteVideos)
+    removeVideosFromPlaylist(toDeleteVideos)
     decrementNumberOfVideosInPlaylist(toDeleteVideos.length)
   } catch {
     // If an error occurs while trying to dynamically update the UI

--- a/src/operations/ui/remove-videos-from-playlist.ts
+++ b/src/operations/ui/remove-videos-from-playlist.ts
@@ -1,12 +1,29 @@
 import { XPATH } from '~src/selectors'
 import getElementsByXpath from '~src/lib/get-elements-by-xpath'
 import listMapSearch from '~src/lib/list-map-search'
-import { PlaylistVideo } from '~src/youtube'
+import { Playlist, PlaylistVideo } from '~src/youtube'
 
-// We don't remove but only hide the videos since
-// Youtube webapp use the indexes to handle some actions (remove, reorder)
-// and removing videos from the DOM collide with that behavior
-export default function hideVideosFromPlaylistUI(videosToDelete: PlaylistVideo[]) {
+function removeVideoWithYtAction(playlist: Playlist, videoId: String) {
+  document.dispatchEvent(
+    new CustomEvent('yt-action', {
+      detail: {
+        actionName: 'yt-service-request',
+        args: [
+          undefined,
+          {
+            playlistEditEndpoint: {
+              clientActions: [{ playlistRemoveVideosAction: { setVideoIds: [videoId] } }],
+              playlistId: playlist.playlistId,
+            },
+          },
+        ],
+        returnValue: [],
+      },
+    })
+  )
+}
+
+export default function removeVideosFromPlaylist(playlist: Playlist, videosToDelete: PlaylistVideo[]) {
   // cast Node as any to access .data property availlable on ytd-playlist-video-renderer elements
   const playlistVideoRendererNodes = getElementsByXpath(XPATH.YT_PLAYLIST_VIDEO_RENDERERS) as any[]
   // All videos to remove MAY be present in the UI because if there is more videos to remove
@@ -20,10 +37,11 @@ export default function hideVideosFromPlaylistUI(videosToDelete: PlaylistVideo[]
     )
     // if all videos to remove are present in the UI
     if (searchMap) {
-      const htmlElements: HTMLElement[] = Object.values(searchMap) as HTMLElement[]
+      const htmlElements = Object.values(searchMap)
       for (const element of htmlElements) {
-        // hide each item from UI
-        element.hidden = true
+        // eslint-disable-next-line no-underscore-dangle
+        const videoId = element.__data.data.setVideoId
+        removeVideoWithYtAction(playlist, videoId)
       }
       return
     }

--- a/src/operations/ui/remove-videos-from-playlist.ts
+++ b/src/operations/ui/remove-videos-from-playlist.ts
@@ -1,19 +1,17 @@
 import { XPATH } from '~src/selectors'
 import getElementsByXpath from '~src/lib/get-elements-by-xpath'
 import listMapSearch from '~src/lib/list-map-search'
-import { Playlist, PlaylistVideo } from '~src/youtube'
+import { PlaylistVideo } from '~src/youtube'
 
-function removeVideoWithYtAction(playlist: Playlist, videoId: String) {
+function removeVideoWithYtAction(videoId: String) {
   document.dispatchEvent(
     new CustomEvent('yt-action', {
       detail: {
-        actionName: 'yt-service-request',
+        actionName: 'yt-playlist-remove-videos-action',
         args: [
-          undefined,
           {
-            playlistEditEndpoint: {
-              clientActions: [{ playlistRemoveVideosAction: { setVideoIds: [videoId] } }],
-              playlistId: playlist.playlistId,
+            playlistRemoveVideosAction: {
+              setVideoIds: [videoId],
             },
           },
         ],
@@ -23,7 +21,7 @@ function removeVideoWithYtAction(playlist: Playlist, videoId: String) {
   )
 }
 
-export default function removeVideosFromPlaylist(playlist: Playlist, videosToDelete: PlaylistVideo[]) {
+export default function removeVideosFromPlaylist(videosToDelete: PlaylistVideo[]) {
   // cast Node as any to access .data property availlable on ytd-playlist-video-renderer elements
   const playlistVideoRendererNodes = getElementsByXpath(XPATH.YT_PLAYLIST_VIDEO_RENDERERS) as any[]
   // All videos to remove MAY be present in the UI because if there is more videos to remove
@@ -41,7 +39,7 @@ export default function removeVideosFromPlaylist(playlist: Playlist, videosToDel
       for (const element of htmlElements) {
         // eslint-disable-next-line no-underscore-dangle
         const videoId = element.__data.data.setVideoId
-        removeVideoWithYtAction(playlist, videoId)
+        removeVideoWithYtAction(videoId)
       }
       return
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This pull request uses what appears to be the same method as YouTube itself uses for video removal, a `yt-action` custom event. Removing a video and breaking on subtree modifications I was able to see the custom event parameters, [these](https://github.com/ParticleCore/Iridium/issues/741#issuecomment-531527494) [sources](https://greasyfork.org/en/scripts/409910-youtube-extension/code) were also helpful.

3fd0a91 replaced the `yt-action` which reduces the complexity as the playlist is not required, the original commit is kept to document the actions.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In a browser with playlists containing one or more videos.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Closing issues

Closes #81.