### PR TITLE
Fix video removal event

### DIFF
--- a/src/operations/ui/remove-videos-from-playlist.ts
+++ b/src/operations/ui/remove-videos-from-playlist.ts
@@ -4,7 +4,7 @@ import listMapSearch from '~src/lib/list-map-search'
 import { PlaylistVideo } from '~src/youtube'
 
 function removeVideoWithYtAction(videoId: String) {
-  document.dispatchEvent(
+  document.querySelectorAll('ytd-app')[0].dispatchEvent(
     new CustomEvent('yt-action', {
       detail: {
         actionName: 'yt-playlist-remove-videos-action',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request fixes the `yt-playlist-remove-videos-action` event after a recent change.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Closing issues

Closes #109.