### PR TITLE
Fix duplicate video removal

### DIFF
--- a/src/operations/ui/remove-videos-from-playlist.ts
+++ b/src/operations/ui/remove-videos-from-playlist.ts
@@ -26,9 +26,10 @@ export default function removeVideosFromPlaylist(videosToDelete: PlaylistVideo[]
   const playlistVideoRendererNodes = getElementsByXpath(XPATH.YT_PLAYLIST_VIDEO_RENDERERS) as any[]
   // All videos to remove MAY be present in the UI because if there is more videos to remove
   // than videos found into the UI, some removed videos aren't loaded in the UI
+  const uniqueVideosToDelete = [...new Map(videosToDelete.map((item) => [item.videoId, item])).values()]
   if (playlistVideoRendererNodes.length >= videosToDelete.length) {
     const searchMap = listMapSearch(
-      videosToDelete,
+      uniqueVideosToDelete,
       playlistVideoRendererNodes,
       (video) => video.videoId,
       (node) => node.data.videoId


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull request fixes an issue where duplicate watched videos in a playlist cause a [videos missing from UI](https://github.com/avallete/yt-playlists-delete-enhancer/blob/8d627cebb281856904a6c5502dbbbb4972bea914/src/operations/ui/remove-videos-from-playlist.ts#L47) error.

The [listMapSearch](https://github.com/avallete/yt-playlists-delete-enhancer/blob/ca000cc6949934ad6f1af4c8ac4713c2a5de270a/src/lib/list-map-search.ts#L9) method expects a unique list of needles, this ensures duplicates are removed first.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Closing issues

Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
