### PR TITLE
Fix append to DOM

### DIFF
--- a/src/operations.ts
+++ b/src/operations.ts
@@ -24,8 +24,12 @@ function mainWrapper() {
     SAPISID: CookieGet('SAPISID') as string,
     ORIGIN_URL: new URL(document.URL).origin,
   }
-  /* eslint-enable no-underscore-dangle */
-  appendAppToDom(config, playlistName, XPATH.APP_RENDER_ROOT)
+
+  document.addEventListener('yt-action', (event: any) => {
+    if (event.detail.actionName === 'ytd-update-grid-state-action') {
+      appendAppToDom(config, playlistName, XPATH.APP_RENDER_ROOT)
+    }
+  })
 }
 
 // Called every time app navigation occurs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull request delays appending to the DOM until after the `ytd-update-grid-state-action` event is dispatched.

## Motivation and Context

Recent changes have resulted in some elements being unavailable on the `DOMContentLoaded` event.

## How Has This Been Tested?

Manually in Chrome with a custom YouTube playlist.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.