### PR TITLE
Fix fetching initial playlist data

### DIFF
--- a/src/yt-api.ts
+++ b/src/yt-api.ts
@@ -1,6 +1,6 @@
 import sha1 from 'sha1'
 import { YTConfigData, PlaylistVideo, Playlist, PlaylistContinuation } from './youtube'
-import { PlaylistNotEditableError, PlaylistEmptyError } from '~src/errors'
+import { PlaylistNotEditableError, PlaylistEmptyError, PlaylistDataFetchError } from '~src/errors'
 
 type YTHeaderKey =
   | 'X-Goog-Visitor-Id'
@@ -113,8 +113,14 @@ async function fetchPlaylistInitialData(config: YTConfigData, playlistName: stri
     method: 'GET',
     mode: 'cors',
   })
-  const data = (await response.json())[1].response.contents.twoColumnBrowseResultsRenderer.tabs[0].tabRenderer.content
-    .sectionListRenderer.contents[0].itemSectionRenderer.contents[0].playlistVideoListRenderer
+
+  let data
+  try {
+    data = (await response.json()).response.contents.twoColumnBrowseResultsRenderer.tabs[0].tabRenderer.content
+      .sectionListRenderer.contents[0].itemSectionRenderer.contents[0].playlistVideoListRenderer
+  } catch {
+    throw PlaylistDataFetchError
+  }
 
   if (!data) {
     throw PlaylistEmptyError


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

YouTube appears to have made some changes again, the response is an object instead of an array. The unused `PlaylistDataFetchError` error has also been repurposed.

## How Has This Been Tested?

In Violentmonkey after building.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
