### PR TITLE
Update XPath expressions and simplify single video behavior

### DIFF
--- a/src/operations/ui/decrement-number-of-videos-in-playlist.ts
+++ b/src/operations/ui/decrement-number-of-videos-in-playlist.ts
@@ -8,17 +8,10 @@ export default function decrementNumberOfVideosInPlaylist(value: number) {
     const newValue = Number(spanElement.textContent) - value
     spanElement.textContent = `${newValue}`
   } else {
-    const spanElementOneVideo: HTMLSpanElement = getElementsByXpath(
-      XPATH.YT_NUMBER_OF_VIDEOS_IN_PLAYLIST_ONE_VIDEO
-    )[0] as HTMLSpanElement
-    if (spanElementOneVideo) {
-      // A reload is performed to properly restore the state of an empty playlist:
-      // - The "There are no videos in this playlist yet" text
-      // - The "No videos" text
-      // Both strings are not part of the `yt.msgs_` object to use for localization
-      window.location.reload()
-    } else {
-      throw new Error('span with the number of videos in playlist not found in DOM')
-    }
+    // A reload is performed to properly restore the state of an empty playlist:
+    // - The "There are no videos in this playlist yet" text
+    // - The "No videos" text
+    // Both strings are not part of the `yt.msgs_` object to use for localization
+    window.location.reload()
   }
 }

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,7 +1,7 @@
 export const XPATH = {
-  APP_RENDER_ROOT: '//div[@class="thumbnail-and-metadata-wrapper style-scope ytd-playlist-header-renderer"]/*[last()]',
+  APP_RENDER_ROOT: '//div[@class="style-scope ytd-playlist-sidebar-renderer"]/*[last()]',
   YT_PLAYLIST_VIDEO_RENDERERS: '//ytd-playlist-video-renderer',
-  YT_NUMBER_OF_VIDEOS_IN_PLAYLIST: '//ytd-playlist-byline-renderer//div/yt-formatted-string/span[1]',
+  YT_NUMBER_OF_VIDEOS_IN_PLAYLIST: '//div[@id="stats"]//yt-formatted-string[1]//span[1]',
 }
 
 export default {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,7 +1,7 @@
 export const XPATH = {
-  APP_RENDER_ROOT: '//div[@class="style-scope ytd-playlist-sidebar-renderer"]/*[last()]',
+  APP_RENDER_ROOT: '//div[@class="immersive-header-content style-scope ytd-playlist-header-renderer"]',
   YT_PLAYLIST_VIDEO_RENDERERS: '//ytd-playlist-video-renderer',
-  YT_NUMBER_OF_VIDEOS_IN_PLAYLIST: '//div[@id="stats"]//yt-formatted-string[1]//span[1]',
+  YT_NUMBER_OF_VIDEOS_IN_PLAYLIST: '//ytd-playlist-byline-renderer//div/yt-formatted-string/span[1]',
 }
 
 export default {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -2,7 +2,6 @@ export const XPATH = {
   APP_RENDER_ROOT: '//div[@class="thumbnail-and-metadata-wrapper style-scope ytd-playlist-header-renderer"]/*[last()]',
   YT_PLAYLIST_VIDEO_RENDERERS: '//ytd-playlist-video-renderer',
   YT_NUMBER_OF_VIDEOS_IN_PLAYLIST: '//ytd-playlist-byline-renderer//div/yt-formatted-string/span[1]',
-  YT_NUMBER_OF_VIDEOS_IN_PLAYLIST_ONE_VIDEO: '//ytd-playlist-byline-renderer/div/yt-formatted-string',
 }
 
 export default {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull request updates the XPath expressions due to YouTube changes. The changes from https://github.com/avallete/yt-playlists-delete-enhancer/pull/104 have been simplified, as if the video count cannot be found or if it is a single video a reload is necessary anyway.

## How Has This Been Tested?

Playlists with single and multiple videos were tested.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
