### PR TITLE
Add mark as unwatched button

### DIFF
--- a/src/components/remove-video-enhancer-app.tsx
+++ b/src/components/remove-video-enhancer-app.tsx
@@ -2,8 +2,9 @@ import { Component } from 'preact'
 import LinearProgress from 'preact-material-components/LinearProgress'
 import RemoveVideoEnhancerContainer from '~components/remove-video-enhancer-container'
 import { YTConfigData, Playlist } from '~src/youtube'
-import { removeVideosFromPlaylist, fetchAllPlaylistContent } from '~src/yt-api'
+import { removeWatchHistoryForVideo, removeVideosFromPlaylist, fetchAllPlaylistContent } from '~src/yt-api'
 import partition from '~lib/partition'
+import removeWatchedFromPlaylistUI from '~src/operations/actions/remove-watched-from-playlist-ui'
 import removeVideosFromPlaylistUI from '~src/operations/actions/remove-videos-from-playlist-ui'
 
 interface Properties {
@@ -21,6 +22,7 @@ export default class RemoveVideoEnhancerApp extends Component<Properties, State>
     super(properties)
     this.state = {}
     this.removeVideoWatchedPercentHandler = this.removeVideoWatchedPercentHandler.bind(this)
+    this.resetVideoHandler = this.resetVideoHandler.bind(this)
     this.removeVideoHandler = this.removeVideoHandler.bind(this)
   }
 
@@ -30,6 +32,15 @@ export default class RemoveVideoEnhancerApp extends Component<Properties, State>
       this.setState({ playlist })
     } catch (error) {
       this.setState({ errorMessages: [error.message] })
+    }
+  }
+
+  async resetVideoHandler(videoId: string) {
+    try {
+      await removeWatchHistoryForVideo(this.props.config, videoId)
+      removeWatchedFromPlaylistUI(videoId)
+    } catch (error) {
+      this.setState({ ...this.state, errorMessages: [error.message] })
     }
   }
 
@@ -98,6 +109,7 @@ export default class RemoveVideoEnhancerApp extends Component<Properties, State>
         return (
           <RemoveVideoEnhancerContainer
             removeVideoWatchedPercentHandler={this.removeVideoWatchedPercentHandler}
+            resetVideoHandler={this.resetVideoHandler}
             removeVideoHandler={this.removeVideoHandler}
           />
         )

--- a/src/components/remove-video-enhancer-container.tsx
+++ b/src/components/remove-video-enhancer-container.tsx
@@ -5,10 +5,12 @@ import Slider from 'preact-material-components/Slider'
 import LinearProgress from 'preact-material-components/LinearProgress'
 import getElementsByXpath from '~lib/get-elements-by-xpath'
 import { XPATH } from '~src/selectors'
+import VideoItemQuickResetButton from './video-item-quick-reset-button'
 import VideoItemQuickDeleteButton from './video-item-quick-delete-button'
 
 interface Properties {
   removeVideoWatchedPercentHandler: (watchTimeValue: number) => Promise<void> | void
+  resetVideoHandler: (videoId: string) => Promise<void> | void
   removeVideoHandler: (videoId: string) => Promise<void> | void
   initialValue?: number
 }
@@ -29,6 +31,7 @@ function validate(value: any): boolean {
 function RemoveVideoEnhancerContainer({
   removeVideoWatchedPercentHandler,
   initialValue = 100,
+  resetVideoHandler,
   removeVideoHandler,
 }: Properties) {
   const [inputValue, setValue] = useState(initialValue)
@@ -46,16 +49,27 @@ function RemoveVideoEnhancerContainer({
     await removeVideoHandler(videoId)
   }, [])
 
+  const resetVideo = useCallback(async (videoId: string) => {
+    await resetVideoHandler(videoId)
+  }, [])
+
   useEffect(() => {
     const menus = getElementsByXpath(XPATH.YT_PLAYLIST_VIDEO_MENU) as HTMLElement[]
     for (const element of menus) {
       element.style.display = 'inline-flex'
       render(
-        h(VideoItemQuickDeleteButton, {
-          // @ts-ignore element.data does not exists on types
-          videoId: element.parentElement?.data.videoId,
-          onClick: removeVideo,
-        }),
+        [
+          h(VideoItemQuickResetButton, {
+            // @ts-ignore element.data does not exists on types
+            videoId: element.parentElement?.data.videoId,
+            onClick: resetVideo,
+          }),
+          h(VideoItemQuickDeleteButton, {
+            // @ts-ignore element.data does not exists on types
+            videoId: element.parentElement?.data.videoId,
+            onClick: removeVideo,
+          }),
+        ],
         element
       )
     }

--- a/src/components/video-item-quick-reset-button.tsx
+++ b/src/components/video-item-quick-reset-button.tsx
@@ -2,7 +2,7 @@ import { useState } from 'preact/hooks'
 
 import IconButton from 'preact-material-components/IconButton'
 
-function VideoItemQuickDeleteButton(properties: { videoId: string; onClick: (videoId: string) => Promise<void> }) {
+function VideoItemQuickResetButton(properties: { videoId: string; onClick: (videoId: string) => Promise<void> }) {
   const [loading, setLoading] = useState(false)
   return (
     <IconButton
@@ -14,11 +14,11 @@ function VideoItemQuickDeleteButton(properties: { videoId: string; onClick: (vid
         setLoading(false)
       }}
       disabled={loading}
-      title='Remove video'
+      title='Mark as unwatched'
     >
-      <IconButton.Icon style={{ color: '#e10000' }}>delete</IconButton.Icon>
+      <IconButton.Icon style={{ color: '#e10000' }}>refresh</IconButton.Icon>
     </IconButton>
   )
 }
 
-export default VideoItemQuickDeleteButton
+export default VideoItemQuickResetButton

--- a/src/operations/actions/remove-watched-from-playlist-ui.ts
+++ b/src/operations/actions/remove-watched-from-playlist-ui.ts
@@ -1,0 +1,12 @@
+import getElementsByXpath from '~src/lib/get-elements-by-xpath'
+import { XPATH } from '~src/selectors'
+
+export default function removeWatchedFromPlaylistUI(videoId: string) {
+  const playlistVideoRendererNodes = getElementsByXpath(XPATH.YT_PLAYLIST_VIDEO_RENDERERS) as any[]
+
+  for (const video of playlistVideoRendererNodes) {
+    if (video.data.videoId === videoId) {
+      video.querySelector('#overlays ytd-thumbnail-overlay-resume-playback-renderer').remove()
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Briefly playing a video can often result in the whole video being marked as watched. Adding this button is a convenient way to prevent actual unwatched videos from being removed when removing all watched videos.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Closing issues

Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
